### PR TITLE
Bug fixes for orange together project

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export class Reach {
 	constructor(url= 'http://webcom.orange.com/base/webrtc') {
 		this.datarefs = datarefs(url);
 		this.webrtcmngr = webrtcmngr(this.datarefs);
+		this.webrtcmngr.setWebrtcManger(this.webrtcmngr);
 	}
 
 	Room(...args) {

--- a/src/localstream.js
+++ b/src/localstream.js
@@ -274,7 +274,9 @@ const localstream = (function() {
 			mLocalStreamVideo=null;
 		}
 		if (streamAudioVideo) {
-			streamAudioVideo.stop();
+			streamAudioVideo.getTracks().forEach((track)=>{
+				track.stop();
+			});
 			streamAudioVideo=null;
 		}
 		if (streamVideo) {

--- a/src/webrtc.js
+++ b/src/webrtc.js
@@ -359,7 +359,7 @@ const webrtc = function (p_webrtcmngr, p_isPublish, p_localDataRef, p_remoteData
 		isVideoMute = mute;
 		const stream = isPublish && sentStream ? sentStream : (!isPublish && receivedStream ? receivedStream : null);
 		if(stream){
-			_muteTracks(!isAudioMute, stream.getVideoTracks());
+			_muteTracks(!isVideoMute, stream.getVideoTracks());
 		}
 	}
 
@@ -760,7 +760,7 @@ const webrtc = function (p_webrtcmngr, p_isPublish, p_localDataRef, p_remoteData
 			if (!!pc && pc.iceConnectionState === ICE_CONNECTION_STATE_DISCONNECTED) {
 				iceConnectionState = ICE_CONNECTION_STATE_DISCONNECTED;
 				console.log(`(ReachSDK::webrtc::oniceconnectionstatechange)stackId=${stackId}-remote disconnection, closing peer connection`);
-				_close();
+				// _close();
 			} else if (!!pc && pc.iceConnectionState === ICE_CONNECTION_STATE_CLOSED) {
 				console.debug(`(ReachSDK::webrtc::oniceconnectionstatechange)stackId=${stackId}-closed`);
 				iceConnectionState = ICE_CONNECTION_STATE_CLOSED;
@@ -768,7 +768,7 @@ const webrtc = function (p_webrtcmngr, p_isPublish, p_localDataRef, p_remoteData
 			} else if (!!pc && pc.iceConnectionState === ICE_CONNECTION_STATE_FAILED) {
 				console.debug(`(ReachSDK::webrtc::oniceconnectionstatechange)stackId=${stackId}-failed`);
 				iceConnectionState = ICE_CONNECTION_STATE_FAILED;
-				_close();
+				//_close();
 			} else {
 				if (pc) {
 					console.debug(`(ReachSDK::webrtc::oniceconnectionstatechange)stackId=${stackId}-${pc.iceConnectionState}`);

--- a/src/webrtcmngr.js
+++ b/src/webrtcmngr.js
@@ -151,11 +151,13 @@ const webrtcmngr = function(datarefs) {
 			console.warn('ReachSDK::webrtcmngr::closeWebrtc cannot found real stack');
 		}
 
-		if (virtualWebrtcStacks[id].localVid) {
-			localstream.close();
-			detachMediaStream(virtualWebrtcStacks[id].localVid);
-		}
+		// if (virtualWebrtcStacks[id].localVid) {
+		// 	localstream.close();
+		// 	detachMediaStream(virtualWebrtcStacks[id].localVid);
+		// }
 		if (virtualWebrtcStacks[id].remoteVid) { detachMediaStream(virtualWebrtcStacks[id].remoteVid);}
+
+		virtualWebrtcStacks.splice(id,1);
 
 		return true;
 	}

--- a/src/webrtcmngr.js
+++ b/src/webrtcmngr.js
@@ -25,6 +25,11 @@ const webrtcmngr = function(datarefs) {
 	const virtualWebrtcStacks = [];
 
 	/**
+	* a work around to be able to get a self reference through setting myself through the Reach class
+	*/
+	let mwebrtcmngr_reference;
+
+	/**
 	 * Creates a WebRTC object
 	 * @param p_Vid - the video container linked to the peerconnection
 	 * @param p_remoteAppInstId - the remote application instance identifier
@@ -68,7 +73,7 @@ const webrtcmngr = function(datarefs) {
 		if (!webrtcStacks[webrtcStackId]) {
 			console.debug('ReachSDK::webrtcmngr::createWebrtc->create a new real webrtcStack');
 			// create the real webrtcstack
-			const webRtcStack = webrtc(this, p_isPublish, localDataRef, remoteDataRef, webrtcStackId, p_actionType, p_mutedAudio, p_muteVideo);
+			const webRtcStack = webrtc(mwebrtcmngr_reference, p_isPublish, localDataRef, remoteDataRef, webrtcStackId, p_actionType, p_mutedAudio, p_muteVideo);
 			webRtcStack.setOnClose(p_onCloseCb);
 			if (p_isPublish) {
 				webrtcStacks[webrtcStackId] = {
@@ -253,6 +258,13 @@ const webrtcmngr = function(datarefs) {
 		}
 
 	}
+	/**
+	 * Setting myself with webrtc manager object
+	 * @param webrtcmngr - The WebRTC manager object
+	 */
+	function _setWebrtcManger(webrtcmngr){
+		mwebrtcmngr_reference= webrtcmngr;
+	}
 
 	return {
 
@@ -265,8 +277,8 @@ const webrtcmngr = function(datarefs) {
 		 * @param p_actionType - The action type (audio, video, audio-video)
 		 * @param p_peercoId - The PeerConnection Id in the webrtc node
 		 */
-		createWebrtc: (p_Vid, p_remoteAppInstId, p_onCloseCb, p_isPublish, p_actionType, p_peercoId, p_mutedAudio, p_muteVideo, p_getStreamCb) => {
-			return  _createWebrtc.bind(this)(p_Vid, p_remoteAppInstId, p_onCloseCb, p_isPublish, p_actionType, p_peercoId, p_mutedAudio, p_muteVideo, p_getStreamCb);
+		createWebrtc: (p_Vid, p_remoteAppInstId, p_onCloseCb, p_isPublish, p_actionType, p_peercoId,p_peercoRef, p_mutedAudio, p_muteVideo, p_getStreamCb) => {
+			return _createWebrtc.bind(this)(p_Vid, p_remoteAppInstId, p_onCloseCb, p_isPublish, p_actionType, p_peercoId, p_peercoRef,p_mutedAudio, p_muteVideo, p_getStreamCb);
 		},
 
 		/**
@@ -301,7 +313,10 @@ const webrtcmngr = function(datarefs) {
 		 * video unmute the webrtc peerconnection
 		 * @param virtualWebrtcStackId - The WebRTC stack ID to unmute
 		 */
-		unmuteVideoWebrtcStack: _unmuteVideoWebrtcStack
+		unmuteVideoWebrtcStack: _unmuteVideoWebrtcStack,
+
+		setWebrtcManger : _setWebrtcManger
+
 	};
 };
 


### PR DESCRIPTION
index.js:
	- workaround: to fix the undefined for webrtcmanager object by setting itself.
-localstream.js:
	- fixed the stopping of streamAudioVideo by stopping streams as stop() doesn't close the video.
-webrtc.js:
	- fixed muting video stream by replace isAudioMute instead of isVideoMute
	- reconnecting video stream when pc isnot closed & ice connection state is failed or closed.
- webrtcmanager.js:
	- workaround: added the self setting reference method
	- added _createWebrtc missing parameter
- room.js:
	- Mathieu's contribution: adding streamId in the roomWebrtcStacks
	- Mathieu's contribution: setting a time out for clearing webrtc stack & removing all the streams on closing a room
	- fix of removeSubscriberListCB to properly retrieve subscriberId & delete of the right stream from the roomWebrtcStacks